### PR TITLE
fix: text overflow

### DIFF
--- a/apps/remix/app/components/MailList.tsx
+++ b/apps/remix/app/components/MailList.tsx
@@ -36,7 +36,7 @@ export function MailItem({ mail: item }: { mail: Email }) {
         </div>
         <div className="text-xs font-medium">{item.subject}</div>
       </div>
-      <div className="line-clamp-2 text-xs text-zinc-300 font-normal">
+      <div className="line-clamp-2 text-xs text-zinc-300 font-normal w-full">
         {item.text || item.html || "".substring(0, 300)}
       </div>
     </Link>

--- a/apps/remix/app/routes/_h._index.tsx
+++ b/apps/remix/app/routes/_h._index.tsx
@@ -130,7 +130,7 @@ export default function Index() {
   return (
     <div className="h-full flex flex-col gap-4 md:flex-row justify-center items-start mt-28 mx-6 md:mx-10">
       <div className="flex flex-col text-white items-start w-full md:w-[350px] mx-auto gap-2">
-        <div className="w-full mb-6 md:max-w-[350px] group group-hover:before:duration-500 group-hover:after:duration-500 after:duration-500 hover:border-cyan-600 hover:before:[box-shadow:_20px_20px_20px_30px_#a21caf] duration-500 before:duration-500 hover:duration-500 hover:after:-right-8 hover:before:right-12 hover:before:-bottom-8 hover:before:blur origin-left hover:decoration-2 relative bg-neutral-800 h-full border text-left p-4 rounded-lg overflow-hidden border-cyan-50/20 before:absolute before:w-12 before:h-12 before:content[''] before:right-1 before:top-1 before:z-10 before:bg-violet-500 before:rounded-full before:blur-lg  after:absolute after:z-10 after:w-20 after:h-20 after:content['']  after:bg-rose-300 after:right-8 after:top-3 after:rounded-full after:blur-lg">
+        <div className="w-full mb-6 md:max-w-[350px] shrink-0 group group-hover:before:duration-500 group-hover:after:duration-500 after:duration-500 hover:border-cyan-600 hover:before:[box-shadow:_20px_20px_20px_30px_#a21caf] duration-500 before:duration-500 hover:duration-500 hover:after:-right-8 hover:before:right-12 hover:before:-bottom-8 hover:before:blur origin-left hover:decoration-2 relative bg-neutral-800 h-full border text-left p-4 rounded-lg overflow-hidden border-cyan-50/20 before:absolute before:w-12 before:h-12 before:content[''] before:right-1 before:top-1 before:z-10 before:bg-violet-500 before:rounded-full before:blur-lg  after:absolute after:z-10 after:w-20 after:h-20 after:content['']  after:bg-rose-300 after:right-8 after:top-3 after:rounded-full after:blur-lg">
           <h1 className="text-gray-50 text-xl font-bold mb-7 group-hover:text-cyan-500 duration-500">
             {t("Virtual Temporary Email")}
           </h1>
@@ -202,7 +202,7 @@ export default function Index() {
         </div>
       </div>
 
-      <div className="w-full flex-1">
+      <div className="w-full flex-1 overflow-hidden">
         <MailListWithQuery mails={loaderData.mails} />
       </div>
     </div>


### PR DESCRIPTION
处理邮件内容文本超长引起的布局问题

Before:
![vmail-pr-before](https://github.com/yesmore/vmail/assets/7608219/14bd36e8-6a54-456b-aace-b5465ce9dfad)

After:
![vmail-pr-after](https://github.com/yesmore/vmail/assets/7608219/8ada398f-d095-4d10-a322-b46fef09eeb7)
